### PR TITLE
always set env even with no variables

### DIFF
--- a/nopa.go
+++ b/nopa.go
@@ -73,9 +73,7 @@ func NewAgent(opts AgentOpts) *Agent {
 		Modifiers:   opts.Modifiers,
 		Cache:       cache.InterQueryCache(interQueryCache),
 	}
-	if opts.Env != nil {
-		a.SetRuntime()
-	}
+	a.SetRuntime()
 
 	return a
 }


### PR DESCRIPTION
Need to always set the env even with no variables to prevent a panic later on.